### PR TITLE
Artemis: Refactor: Use list comprehension for sum_range and sum_modulus

### DIFF
--- a/src/llm_benchmark/control/single.py
+++ b/src/llm_benchmark/control/single.py
@@ -12,10 +12,7 @@ class SingleForLoop:
         Returns:
             int: Sum of range of numbers from 0 to n
         """
-        arr = []
-        for i in range(n):
-            arr.append(i)
-        return sum(arr)
+        return sum([i for i in range(n)])
 
     @staticmethod
     def max_list(v: List[int]) -> int:
@@ -44,8 +41,4 @@ class SingleForLoop:
         Returns:
             int: Sum of modulus of numbers from 0 to n
         """
-        arr = []
-        for i in range(n):
-            if i % m == 0:
-                arr.append(i)
-        return sum(arr)
+        return sum([i for i in range(n) if i % m == 0])


### PR DESCRIPTION
This commit replaces the explicit loop and list appending in the `sum_range` and `sum_modulus` methods with list comprehensions. This makes the code more concise and readable. The `sum_range` method now calculates the sum using the expression `sum([i for i in range(n)])`, which generates a list of numbers from 0 to `n` and then sums them. Similarly, the `sum_modulus` method uses `sum([i for i in range(n) if i % m == 0])`, which generates a list of numbers from 0 to `n` that are divisible by `m` and then sums them. This change improves the readability and conciseness of the code while maintaining the functionality.
